### PR TITLE
Remove start postgresql information in setup devenv script

### DIFF
--- a/scripts/setup-devenv.sh
+++ b/scripts/setup-devenv.sh
@@ -28,12 +28,6 @@
 #     brew install gnu-sed
 #
 # Before running this script
-# - Start postgresql
-#
-#   This can be either an own managed instance, or one can use our docker compose script:
-#
-#     docker compose -f wallet_core/wallet_provider/docker-compose.yml up
-#
 # - Android Emulator configuration
 #
 #     ./scripts/map_android_ports.sh


### PR DESCRIPTION
The script `wallet_core/wallet_provider/docker-compose.yml` does not exist anymore.

The new script is `scripts/docker-compose.yml` but this script is already used by the `start-devenv.sh` script.

So I think this information can be removed, please correct me if I am wrong.