### PR TITLE
Create CA serial file when generating ssl certs for devenv

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -119,6 +119,7 @@ function generate_ssl_key_pair_with_san {
             -days 500 \
             -CA "$3" \
             -CAkey "$4" \
+            -CAcreateserial \
             -out "$1/$2.crt" \
             -extensions req_ext \
             -extfile "${DEVENV}/openssl-san.cfg" > /dev/null


### PR DESCRIPTION
When running the ` ./scripts/setup-devenv.sh` script I got the following output.

```bash
Generating SSL CERT from CSR
Signature ok
subject=C = US, CN = localhost
Getting CA Private Key
/..../minbzk/nl-wallet/scripts/devenv/target/configuration_server/ca.crt.srl: No such file or directory
140448814343488:error:06067099:digital envelope routines:EVP_PKEY_copy_parameters:different parameters:../crypto/evp/p_lib.c:93:
140448814343488:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('/..../minbzk/nl-wallet/scripts/devenv/target/configuration_server/ca.crt.srl','r')
140448814343488:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
```

So it was missing the `ca.crt.srl` file. After adding the `-CAcreateserial` option to the `openssl x509` command the issue is resolved because OpenSSL will create the serial file if the file does not exist.

See also the OpenSSL documentation https://docs.openssl.org/3.0/man1/openssl-x509/#micro-ca-options.