### PR TITLE
feat(android): support registration on devices without Google Play Integrity (de-Googled)

### DIFF
--- a/scripts/devenv/wallet_provider.toml.template
+++ b/scripts/devenv/wallet_provider.toml.template
@@ -76,3 +76,15 @@ root_public_keys = [
 ]
 package_name = "nl.ictu.edi.wallet.latest"
 allow_sideloading = true
+
+# Optional: accept registrations from devices without Google Play services or a Google account
+# (e.g. GrapheneOS, LineageOS, /e/OS) using hardware key attestation alone, without a Play Integrity
+# token. Disabled unless `enabled = true`. The conditions below keep a hardware root of trust, so this
+# is a replacement of the Play Integrity signal rather than a removal of device integrity.
+# [android.key_attestation_only]
+# enabled = false
+# # Verified boot states to accept. "verified" is the strongest (locked bootloader + verified OS,
+# # including relocked GrapheneOS). Add "self_signed"/"unverified" only after weighing the risk.
+# allowed_verified_boot_states = ["verified"]
+# require_device_locked = true
+# require_matching_signature_digest = true

--- a/wallet_core/lib/android_attest/src/attestation_extension/key_attestation.rs
+++ b/wallet_core/lib/android_attest/src/attestation_extension/key_attestation.rs
@@ -28,6 +28,8 @@ use super::key_description;
 use super::key_description::KeyDescription;
 use super::key_description::RootOfTrust;
 use super::key_description::SecurityLevel;
+#[cfg(feature = "mock")]
+use super::key_description::VerifiedBootState;
 
 macro_rules! integer_int_enum_conversion {
     ($type:ty, $repr:ty, $error_type:ident, $invalid_error:ident) => {
@@ -556,6 +558,48 @@ impl KeyAttestation {
             .map_err(KeyAttestationVerificationError::KeyMintSecurityLevel)?;
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "mock")]
+impl KeyAttestation {
+    /// Construct a parsed key attestation for tests, with a hardware-enforced root of trust and a
+    /// software-enforced application id. Useful for exercising server-side key attestation policies
+    /// (e.g. the key-attestation-only registration path) without producing a real certificate chain.
+    pub fn new_mock(
+        attestation_security_level: SecurityLevel,
+        verified_boot_state: VerifiedBootState,
+        device_locked: bool,
+        package_name: &str,
+        signature_digests: Vec<Vec<u8>>,
+    ) -> Self {
+        KeyAttestation {
+            attestation_version: AttestationVersion::V400,
+            attestation_security_level,
+            key_mint_version: KeyMintVersion::V400,
+            key_mint_security_level: attestation_security_level,
+            attestation_challenge: OctetString::copy_from_slice(b"challenge"),
+            unique_id: OctetString::copy_from_slice(b"unique_id"),
+            software_enforced: AuthorizationList {
+                attestation_application_id: Some(AttestationApplicationId {
+                    package_infos: SetOf::from_vec(vec![AttestationPackageInfo {
+                        package_name: OctetString::copy_from_slice(package_name.as_bytes()),
+                        version: 0.into(),
+                    }]),
+                    signature_digests: SetOf::from_vec(signature_digests.into_iter().map(OctetString::from).collect()),
+                }),
+                ..Default::default()
+            },
+            hardware_enforced: AuthorizationList {
+                root_of_trust: Some(RootOfTrust {
+                    verified_boot_key: OctetString::copy_from_slice(&[0u8; 32]),
+                    device_locked,
+                    verified_boot_state,
+                    verified_boot_hash: OctetString::copy_from_slice(&[0u8; 32]),
+                }),
+                ..Default::default()
+            },
+        }
     }
 }
 

--- a/wallet_core/wallet/platform_support/README.md
+++ b/wallet_core/wallet/platform_support/README.md
@@ -281,3 +281,25 @@ Before running these tests:
 * Connect a physical device
 * Enable the corresponding opt-in close proximity test constant in the iOS or Android test file.
 * Grant Bluetooth access to the terminal app that runs the Mac helper.
+
+# Android app attestation on devices without Google Play services
+
+On Android, key/app attestation normally combines a hardware **key attestation**
+certificate chain (produced by the Android Keystore, which does not require
+Google) with a Google **Play Integrity** token (which does require Google Play
+services and, in practice, a Google account).
+
+To support de-Googled devices (e.g. GrapheneOS, LineageOS, /e/OS), the
+`AttestedKeyBridge` degrades gracefully: when Play Integrity is unavailable
+because the device has no Google Play services / Play Store, or no Google
+account is signed in, it returns the key attestation certificate chain with a
+`null` app attestation token instead of failing. This is detected via the
+specific Play Integrity error codes in `PLAY_INTEGRITY_UNAVAILABLE_ERROR_CODES`;
+transient failures on genuine Google devices are still retried and surfaced, so
+those devices are not silently downgraded.
+
+The `app_attestation_token` is therefore optional throughout the attestation
+types (`AttestationData::Google`, `KeyWithAttestation::Google`,
+`RegistrationAttestation::Google`). The account server validates the hardware
+key attestation against its configured policy when no token is present; see the
+`wallet_provider` README.

--- a/wallet_core/wallet/platform_support/android/src/androidTest/kotlin/nl/rijksoverheid/edi/wallet/platform_support/attested_key/AttestedKeyBridgeInstrumentedTest.kt
+++ b/wallet_core/wallet/platform_support/android/src/androidTest/kotlin/nl/rijksoverheid/edi/wallet/platform_support/attested_key/AttestedKeyBridgeInstrumentedTest.kt
@@ -93,8 +93,9 @@ class AttestedKeyBridgeInstrumentedTest {
         if (attestationData is AttestationData.Google) {
             // Note that appAttestationToken is encrypted and is not decrypted
             // by the wallet_app, but by the backend (wallet_provider). Hence,
-            // here, we only check that the response is not empty.
-            assert(attestationData.appAttestationToken.isNotEmpty())
+            // here, we only check that the response is not empty. This test runs on a
+            // Google Play enabled emulator, so a token is expected to be present.
+            assert(attestationData.appAttestationToken?.isNotEmpty() == true)
             // Verify that the certificate chain is not empty
             assert(attestationData.certificateChain.size >= 2) {
                 "expected at least the root certificate and the key's certificate"

--- a/wallet_core/wallet/platform_support/android/src/main/kotlin/nl/rijksoverheid/edi/wallet/platform_support/attested_key/AttestedKeyBridge.kt
+++ b/wallet_core/wallet/platform_support/android/src/main/kotlin/nl/rijksoverheid/edi/wallet/platform_support/attested_key/AttestedKeyBridge.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.google.android.play.core.integrity.IntegrityManagerFactory
+import com.google.android.play.core.integrity.StandardIntegrityException
 import com.google.android.play.core.integrity.StandardIntegrityManager.*
+import com.google.android.play.core.integrity.model.StandardIntegrityErrorCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,6 +31,26 @@ import uniffi.platform_support.AttestedKeyBridge as RustAttestedKeyBridge
 private const val ATTESTED_KEY_PREFIX = "ecdsa_"
 
 private fun String.keyAlias() = ATTESTED_KEY_PREFIX + this
+
+/**
+ * Play Integrity error codes that indicate this device fundamentally cannot produce an integrity
+ * token: it has no Google Play services / Play Store, or no Google account is present. These are the
+ * cases for de-Googled devices (e.g. GrapheneOS, LineageOS, /e/OS) and for devices without a signed-in
+ * Google account. When any of these occurs we fall back to hardware key attestation only, instead of
+ * failing registration. Transient errors (network, internal, etc.) are intentionally NOT in this set,
+ * so genuine Google devices still must produce a valid integrity token.
+ */
+private val PLAY_INTEGRITY_UNAVAILABLE_ERROR_CODES = setOf(
+    StandardIntegrityErrorCode.API_NOT_AVAILABLE,
+    StandardIntegrityErrorCode.PLAY_STORE_NOT_FOUND,
+    StandardIntegrityErrorCode.PLAY_SERVICES_NOT_FOUND,
+    StandardIntegrityErrorCode.PLAY_STORE_ACCOUNT_NOT_FOUND,
+    StandardIntegrityErrorCode.PLAY_STORE_VERSION_OUTDATED,
+    StandardIntegrityErrorCode.PLAY_SERVICES_VERSION_OUTDATED,
+)
+
+private fun Exception.indicatesPlayIntegrityUnavailable(): Boolean =
+    this is StandardIntegrityException && errorCode in PLAY_INTEGRITY_UNAVAILABLE_ERROR_CODES
 
 /**
  * This class is automatically initialized on app start through
@@ -63,9 +85,12 @@ class AttestedKeyBridge(context: Context) : KeyBridge(context), RustAttestedKeyB
                 .build()
 
             // Retryably execute integrity token provider request, await result, fill integrityTokenProvider.
+            // A permanent "Play Integrity unavailable" failure (de-Googled device / no Google account) is
+            // not retried but propagated immediately, so the caller can fall back to key attestation only.
             integrityTokenProvider = retryable(
                 taskName = "attest",
-                taskDescription = "obtaining integrity token provider"
+                taskDescription = "obtaining integrity token provider",
+                nonRetryable = { it.indicatesPlayIntegrityUnavailable() }
             ) { integrityManager.prepareIntegrityToken(integrityTokenProviderRequest).await() }
 
             // Set last as this is used to check for init.
@@ -83,23 +108,37 @@ class AttestedKeyBridge(context: Context) : KeyBridge(context), RustAttestedKeyB
     @OptIn(ExperimentalEncodingApi::class)
     @Throws(AttestedKeyException::class)
     override suspend fun attest(identifier: String, challenge: List<UByte>, googleCloudProjectNumber: ULong): AttestationData = withContext(Dispatchers.IO) {
-        // Initialize integrity token provider.
-        initializeIntegrityTokenProvider(googleCloudProjectNumber)
+        // Try to obtain a Google Play Integrity token. On devices without Google Play services / Play
+        // Store, or without a signed-in Google account, this is not possible. In that case we degrade
+        // gracefully to a `null` token and rely on hardware key attestation alone; the account server
+        // validates the key attestation certificate chain against its configured policy.
+        val appAttestationToken: String? = try {
+            // Initialize integrity token provider.
+            initializeIntegrityTokenProvider(googleCloudProjectNumber)
 
-        // Retryably execute integrity token request using provider, await result, fill integrityToken.
-        val integrityTokenRequest = StandardIntegrityTokenRequest.builder().setRequestHash(Base64.Default.encode(challenge.toByteArray())).build()
-        val integrityToken = retryable(
-            taskName = "attest",
-            taskDescription = "obtaining integrity token"
-        ) { integrityTokenProvider.request(integrityTokenRequest).await() }
+            // Retryably execute integrity token request using provider, await result, fill integrityToken.
+            val integrityTokenRequest = StandardIntegrityTokenRequest.builder().setRequestHash(Base64.Default.encode(challenge.toByteArray())).build()
+            val integrityToken = retryable(
+                taskName = "attest",
+                taskDescription = "obtaining integrity token",
+                nonRetryable = { it.indicatesPlayIntegrityUnavailable() }
+            ) { integrityTokenProvider.request(integrityTokenRequest).await() }
+
+            integrityToken.token()
+        } catch (e: Exception) {
+            if (e.indicatesPlayIntegrityUnavailable()) {
+                Log.i("attest", "Google Play Integrity unavailable on this device (no Play services / Play Store / Google account); falling back to hardware key attestation only")
+                null
+            } else {
+                throw e
+            }
+        }
 
         val signingKey = createKey(identifier, challenge)
         try {
             val certificateChain =
                 signingKey.getCertificateChain()?.asSequence()?.map { it.encoded.toUByteList() }?.toList()
                     ?: throw AttestedKeyException.Other("failed to get certificate chain")
-
-            val appAttestationToken = integrityToken.token()
 
             AttestationData.Google(certificateChain, appAttestationToken)
         } catch (e: Exception) {

--- a/wallet_core/wallet/platform_support/android/src/main/kotlin/nl/rijksoverheid/edi/wallet/platform_support/utilities/RetryHelper.kt
+++ b/wallet_core/wallet/platform_support/android/src/main/kotlin/nl/rijksoverheid/edi/wallet/platform_support/utilities/RetryHelper.kt
@@ -13,6 +13,7 @@ suspend fun <T> retryable(
     factor: Double = 2.0,
     taskName: String = "retry",
     taskDescription: String = "retryable-task",
+    nonRetryable: (Exception) -> Boolean = { false },
     block: suspend () -> T): T
 {
     var currentDelay = initialDelay
@@ -23,6 +24,12 @@ suspend fun <T> retryable(
         try {
             return block()
         } catch (e: Exception) {
+            // Some failures are permanent (e.g. the device has no Google Play services at all);
+            // retrying those only wastes time, so rethrow them immediately.
+            if (nonRetryable(e)) {
+                Log.i(taskName, "caught non-retryable ${e.javaClass.name} (description: ${taskDescription}, exception message: \"${e.message}\"), not retrying..")
+                throw e
+            }
             if (attempt == times) {
                 Log.e(taskName, "caught ${e.javaClass.name} (description: ${taskDescription}, exception message: \"${e.message}\"), giving up..")
                 throw e

--- a/wallet_core/wallet/platform_support/src/attested_key/mock.rs
+++ b/wallet_core/wallet/platform_support/src/attested_key/mock.rs
@@ -536,10 +536,11 @@ mod google {
             key_identifier: String,
             ca_chain: &MockCaChain,
             challenge: Vec<u8>,
-        ) -> (MockGoogleAttestedKey, Vec<Vec<u8>>, String) {
+        ) -> (MockGoogleAttestedKey, Vec<Vec<u8>>, Option<String>) {
             // The token is simply the Base64 encoded challenge hash, which can then be used by
             // a mock Play Integrity implementation in order to generate an integrity verdict.
-            let app_attestation_token = BASE64_STANDARD.encode(&challenge);
+            // The mock emulates a device with Google Play services, so a token is always produced.
+            let app_attestation_token = Some(BASE64_STANDARD.encode(&challenge));
 
             let key_description = KeyDescription::new_valid_mock(challenge);
 

--- a/wallet_core/wallet/platform_support/src/attested_key/mod.rs
+++ b/wallet_core/wallet/platform_support/src/attested_key/mod.rs
@@ -114,7 +114,10 @@ pub enum KeyWithAttestation<A, G> {
     Google {
         key: G,
         certificate_chain: Vec<Vec<u8>>,
-        app_attestation_token: String,
+        /// Google Play Integrity token. `None` on devices without Google Play services
+        /// (e.g. GrapheneOS, LineageOS, /e/OS), in which case registration relies on the
+        /// hardware key attestation certificate chain alone.
+        app_attestation_token: Option<String>,
     },
 }
 

--- a/wallet_core/wallet/platform_support/src/attested_key/test.rs
+++ b/wallet_core/wallet/platform_support/src/attested_key/test.rs
@@ -162,7 +162,7 @@ pub async fn create_and_verify_attested_key<'a, H>(
             app_attestation_token,
         } => {
             assert!(
-                !app_attestation_token.is_empty(),
+                app_attestation_token.as_ref().is_some_and(|token| !token.is_empty()),
                 "App attestation token should not be empty"
             );
 

--- a/wallet_core/wallet/platform_support/src/bridge/attested_key.rs
+++ b/wallet_core/wallet/platform_support/src/bridge/attested_key.rs
@@ -30,7 +30,10 @@ pub enum AttestationData {
     },
     Google {
         certificate_chain: Vec<Vec<u8>>,
-        app_attestation_token: String,
+        /// Google Play Integrity token. `None` on devices without Google Play services
+        /// (e.g. GrapheneOS, LineageOS, /e/OS), in which case registration relies on the
+        /// hardware key attestation certificate chain alone.
+        app_attestation_token: Option<String>,
     },
 }
 

--- a/wallet_core/wallet/platform_support/udl/platform_support.udl
+++ b/wallet_core/wallet/platform_support/udl/platform_support.udl
@@ -67,7 +67,7 @@ enum AttestedKeyType {
 [Enum]
 interface AttestationData {
     Apple(sequence<u8> attestation_data);
-    Google(sequence<sequence<u8>> certificate_chain, string app_attestation_token);
+    Google(sequence<sequence<u8>> certificate_chain, string? app_attestation_token);
 };
 
 /// Combines a collection of methods that unify working with attested keys on both

--- a/wallet_core/wallet_provider/README.md
+++ b/wallet_core/wallet_provider/README.md
@@ -78,3 +78,37 @@ RUST_LOG=debug cargo run --bin wallet_provider
 If the log level is at least debug (as above), it will output the public keys
 that are derived from the private keys.
 This can then be used in development of the Wallet app.
+
+## Android registration without Google Play Integrity (de-Googled devices)
+
+By default, an Android wallet registration must provide both a hardware key
+attestation certificate chain **and** a Google Play Integrity token. The Play
+Integrity token requires Google Play services and, in practice, a Google
+account, which excludes de-Googled devices (e.g. GrapheneOS, LineageOS, /e/OS).
+
+The Wallet Provider can optionally accept registrations that rely on the
+hardware key attestation alone, without a Play Integrity token. This keeps a
+hardware root of trust (it is a replacement of the integrity signal, not a
+removal): the policy requires a hardware-backed attestation security level,
+checks the verified boot state and bootloader lock state from the attestation's
+root of trust, and binds the attestation to our app via the
+`attestation_application_id` (package name and, optionally, signing certificate
+digest). See `KeyAttestationOnlyPolicy` in
+`service/src/account_server.rs`.
+
+This path is **disabled by default**. Enable it in the settings under
+`[android.key_attestation_only]`:
+
+```toml
+[android.key_attestation_only]
+enabled = true
+# "verified" is the strongest state (locked bootloader + verified OS, including
+# relocked GrapheneOS). Accepting "self_signed"/"unverified" weakens the
+# guarantee and should be a deliberate policy decision.
+allowed_verified_boot_states = ["verified"]
+require_device_locked = true
+require_matching_signature_digest = true
+```
+
+When no token is present and this policy is not configured, the registration is
+rejected, preserving the default behaviour.

--- a/wallet_core/wallet_provider/domain/src/model/wallet_user.rs
+++ b/wallet_core/wallet_provider/domain/src/model/wallet_user.rs
@@ -130,7 +130,9 @@ pub enum WalletUserAttestationCreate {
     },
     Android {
         certificate_chain: Vec<Vec<u8>>,
-        integrity_verdict_json: String,
+        /// The verified Play Integrity verdict as a JSON string, or `None` when the device
+        /// registered using hardware key attestation alone (no Google Play services / account).
+        integrity_verdict_json: Option<String>,
         identifiers: AndroidHardwareIdentifiers,
     },
 }

--- a/wallet_core/wallet_provider/migrations/src/lib.rs
+++ b/wallet_core/wallet_provider/migrations/src/lib.rs
@@ -9,6 +9,7 @@ mod m20250102_000030_create_wallet_transfer_table;
 mod m20251107_154522_create_wallet_user_wua_table;
 mod m20260202_105409_create_recovery_code_table;
 mod m20260202_120929_create_wallet_flag_table;
+mod m20260602_000001_make_android_integrity_verdict_nullable;
 
 pub struct Migrator;
 
@@ -26,6 +27,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20251107_154522_create_wallet_user_wua_table::Migration),
             Box::new(m20260202_105409_create_recovery_code_table::Migration),
             Box::new(m20260202_120929_create_wallet_flag_table::Migration),
+            Box::new(m20260602_000001_make_android_integrity_verdict_nullable::Migration),
         ];
         migrations.extend(wallet_provider_migrations);
 

--- a/wallet_core/wallet_provider/migrations/src/m20260602_000001_make_android_integrity_verdict_nullable.rs
+++ b/wallet_core/wallet_provider/migrations/src/m20260602_000001_make_android_integrity_verdict_nullable.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Devices without Google Play services (e.g. GrapheneOS, LineageOS, /e/OS) or without a
+        // Google account cannot produce a Play Integrity verdict and register using hardware key
+        // attestation alone. For those wallet users no integrity verdict is stored, so the column
+        // must allow NULL values.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WalletUserAndroidAttestation::Table)
+                    .modify_column(
+                        ColumnDef::new(WalletUserAndroidAttestation::IntegrityVerdictJson)
+                            .string()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+pub enum WalletUserAndroidAttestation {
+    Table,
+    IntegrityVerdictJson,
+}

--- a/wallet_core/wallet_provider/persistence/src/entity/wallet_user_android_attestation.rs
+++ b/wallet_core/wallet_provider/persistence/src/entity/wallet_user_android_attestation.rs
@@ -8,7 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
     pub certificate_chain: Vec<Vec<u8>>,
-    pub integrity_verdict_json: String,
+    pub integrity_verdict_json: Option<String>,
     pub brand: Option<String>,
     pub model: Option<String>,
     pub os_version: Option<i32>,

--- a/wallet_core/wallet_provider/persistence/src/test.rs
+++ b/wallet_core/wallet_provider/persistence/src/test.rs
@@ -76,7 +76,7 @@ where
         },
         WalletDeviceVendor::Google => WalletUserAttestationCreate::Android {
             certificate_chain: vec![random_bytes(64)],
-            integrity_verdict_json: "{}".to_string(),
+            integrity_verdict_json: Some("{}".to_string()),
             identifiers: AndroidHardwareIdentifiers {
                 brand: Some("Brand Name".to_string()),
                 model: Some("Model Name".to_string()),

--- a/wallet_core/wallet_provider/service/src/account_server.rs
+++ b/wallet_core/wallet_provider/service/src/account_server.rs
@@ -8,6 +8,9 @@ use std::time::Duration;
 use android_attest::android_crl;
 use android_attest::android_crl::GoogleRevocationListClient;
 use android_attest::android_crl::RevocationStatusList;
+use android_attest::attestation_extension::key_attestation::KeyAttestation;
+use android_attest::attestation_extension::key_description::SecurityLevel;
+use android_attest::attestation_extension::key_description::VerifiedBootState;
 use android_attest::certificate_chain::GoogleKeyAttestationError;
 use android_attest::certificate_chain::verify_google_key_attestation_with_params;
 use android_attest::play_integrity::client::PlayIntegrityClient;
@@ -181,6 +184,20 @@ pub enum AndroidKeyAttestationError {
     Verification(#[from] GoogleKeyAttestationError),
     #[error("certificate chain contains at least one revoked certificate")]
     RevokedCertificates,
+    #[error("Play Integrity token is required: key-attestation-only registration is not enabled")]
+    IntegrityTokenRequired,
+    #[error("key attestation security level is not hardware-backed: {0:?}")]
+    InsufficientSecurityLevel(SecurityLevel),
+    #[error("key attestation does not contain a hardware-enforced root of trust")]
+    MissingRootOfTrust,
+    #[error("key attestation verified boot state is not accepted: {0:?}")]
+    VerifiedBootStateNotAccepted(VerifiedBootState),
+    #[error("key attestation indicates the bootloader is not locked")]
+    BootloaderNotLocked,
+    #[error("key attestation application identity does not match expected package '{0}'")]
+    ApplicationIdentityMismatch(String),
+    #[error("key attestation signature digest does not match a configured app signing certificate")]
+    SignatureDigestMismatch,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -458,6 +475,100 @@ pub struct AndroidAttestationConfiguration {
     pub package_name: String,
     pub installation_method: InstallationMethod,
     pub certificate_hashes: HashSet<Vec<u8>>,
+    /// Policy for accepting registrations that rely on hardware key attestation alone, without a
+    /// Google Play Integrity token (e.g. devices without Google Play services or a Google account).
+    /// `None` disables this path entirely, preserving the default behaviour of requiring a Play
+    /// Integrity verdict for every Android device.
+    pub key_attestation_only_policy: Option<KeyAttestationOnlyPolicy>,
+}
+
+/// Conditions under which a registration without a Google Play Integrity token is accepted, relying
+/// on the hardware key attestation certificate chain alone. The hardware-backed security level is
+/// always required (a software-only attestation is never accepted). The remaining conditions are
+/// configurable so that a deployment can decide, as a matter of policy, which de-Googled devices and
+/// bootloader states it trusts.
+#[derive(Debug, Clone)]
+pub struct KeyAttestationOnlyPolicy {
+    /// Verified boot states accepted when no Play Integrity token is present. For the strongest
+    /// guarantee a deployment accepts only [`VerifiedBootState::Verified`] (a device with a locked
+    /// bootloader and a verified OS, including relocked GrapheneOS).
+    pub allowed_verified_boot_states: Vec<VerifiedBootState>,
+    /// Require a locked bootloader (`RootOfTrust.device_locked == true`).
+    pub require_device_locked: bool,
+    /// Require that one of the app signing certificate digests in the key attestation's
+    /// `attestation_application_id` matches the configured `certificate_hashes`. This replaces the
+    /// app-authenticity guarantee that Play Integrity would otherwise provide.
+    pub require_matching_signature_digest: bool,
+}
+
+/// Verify a key-attestation-only registration (no Play Integrity token) against `policy`. This
+/// enforces a hardware root of trust and binds the attestation to our app, so that dropping Play
+/// Integrity for de-Googled devices is a replacement of the integrity signal rather than a removal.
+fn verify_key_attestation_only_policy(
+    key_attestation: &KeyAttestation,
+    config: &AndroidAttestationConfiguration,
+    policy: &KeyAttestationOnlyPolicy,
+) -> Result<(), AndroidKeyAttestationError> {
+    // 1. The attestation must be hardware-backed; a software-only attestation provides no hardware root of trust and is
+    //    never accepted on this path.
+    if matches!(key_attestation.attestation_security_level, SecurityLevel::Software) {
+        return Err(AndroidKeyAttestationError::InsufficientSecurityLevel(
+            key_attestation.attestation_security_level,
+        ));
+    }
+
+    // 2. Verified boot state and bootloader lock state, taken from the hardware-enforced root of trust.
+    let root_of_trust = key_attestation
+        .hardware_enforced
+        .root_of_trust
+        .as_ref()
+        .ok_or(AndroidKeyAttestationError::MissingRootOfTrust)?;
+
+    if !policy
+        .allowed_verified_boot_states
+        .contains(&root_of_trust.verified_boot_state)
+    {
+        return Err(AndroidKeyAttestationError::VerifiedBootStateNotAccepted(
+            root_of_trust.verified_boot_state,
+        ));
+    }
+
+    if policy.require_device_locked && !root_of_trust.device_locked {
+        return Err(AndroidKeyAttestationError::BootloaderNotLocked);
+    }
+
+    // 3. App identity binding: the attested application id (populated by Android KeyMint, not by the app) must
+    //    reference our package and, optionally, match a configured app signing certificate digest. KeyMint records the
+    //    application id in the software-enforced authorization list.
+    let application_id = key_attestation
+        .software_enforced
+        .attestation_application_id
+        .as_ref()
+        .ok_or_else(|| AndroidKeyAttestationError::ApplicationIdentityMismatch(config.package_name.clone()))?;
+
+    let package_matches = application_id
+        .package_infos
+        .to_vec()
+        .iter()
+        .any(|info| info.package_name.as_ref() == config.package_name.as_bytes());
+    if !package_matches {
+        return Err(AndroidKeyAttestationError::ApplicationIdentityMismatch(
+            config.package_name.clone(),
+        ));
+    }
+
+    if policy.require_matching_signature_digest {
+        let digest_matches = application_id
+            .signature_digests
+            .to_vec()
+            .iter()
+            .any(|digest| config.certificate_hashes.contains(digest.as_ref()));
+        if !digest_matches {
+            return Err(AndroidKeyAttestationError::SignatureDigestMismatch);
+        }
+    }
+
+    Ok(())
 }
 
 pub struct AccountServerKeys {
@@ -691,50 +802,82 @@ impl<GRC, PIC> AccountServer<GRC, PIC> {
                 let hw_pubkey = VerifyingKey::from_public_key_der(leaf_certificate.public_key().raw)
                     .map_err(|error| AndroidKeyAttestationError::LeafPublicKey(Box::new(error)))?;
 
-                debug!("Validating Android app attestation");
+                // Validate the Android app attestation. When a Play Integrity token is present we verify
+                // it as usual. When it is absent (e.g. a de-Googled device without Google Play services,
+                // or a device without a Google account), we fall back to validating the hardware key
+                // attestation alone, subject to the configured key attestation policy. This keeps a
+                // hardware root of trust without requiring Google Play services or a Google account.
+                let integrity_verdict_json = match integrity_token {
+                    Some(integrity_token) => {
+                        debug!("Validating Android app attestation using Play Integrity");
 
-                let (integrity_verdict, integrity_verdict_json) = self
-                    .play_integrity_client
-                    .decode_token(&integrity_token)
-                    .await
-                    .map_err(|error| {
-                        warn!("Could not decode integrity token using Play Integrity API: {0}", error);
+                        let (integrity_verdict, integrity_verdict_json) = self
+                            .play_integrity_client
+                            .decode_token(&integrity_token)
+                            .await
+                            .map_err(|error| {
+                                warn!("Could not decode integrity token using Play Integrity API: {0}", error);
 
-                        AndroidAppAttestationError::DecodeIntegrityToken
-                    })?;
+                                AndroidAppAttestationError::DecodeIntegrityToken
+                            })?;
 
-                let request_hash = BASE64_STANDARD.encode(&challenge_hash);
+                        let request_hash = BASE64_STANDARD.encode(&challenge_hash);
 
-                #[cfg(feature = "spoof_integrity_verdict_hash")]
-                let integrity_verdict = {
-                    use android_attest::play_integrity::integrity_verdict::RequestDetails;
+                        #[cfg(feature = "spoof_integrity_verdict_hash")]
+                        let integrity_verdict = {
+                            use android_attest::play_integrity::integrity_verdict::RequestDetails;
 
-                    warn!("Spoofing Android integrity verdict request hash");
+                            warn!("Spoofing Android integrity verdict request hash");
 
-                    IntegrityVerdict {
-                        request_details: RequestDetails {
-                            request_hash: request_hash.clone(),
-                            ..integrity_verdict.request_details
-                        },
-                        ..integrity_verdict
+                            IntegrityVerdict {
+                                request_details: RequestDetails {
+                                    request_hash: request_hash.clone(),
+                                    ..integrity_verdict.request_details
+                                },
+                                ..integrity_verdict
+                            }
+                        };
+
+                        let _ = VerifiedIntegrityVerdict::verify_with_time(
+                            integrity_verdict,
+                            &self.android_config.package_name,
+                            &request_hash,
+                            &self.android_config.certificate_hashes,
+                            self.android_config.installation_method,
+                            attestation_timestamp,
+                        )
+                        .map_err(|error| {
+                            warn!(
+                                "rejected Android app attestation with integrity verdict: '{0}', cause: '{error}'",
+                                integrity_verdict_json,
+                            );
+                            AndroidAppAttestationError::IntegrityVerdict(error)
+                        })?;
+
+                        Some(integrity_verdict_json)
+                    }
+                    None => {
+                        // No Play Integrity token: only allowed when the deployment has explicitly opted
+                        // in to key-attestation-only registration to support devices without Google Play
+                        // services (e.g. GrapheneOS, LineageOS, /e/OS).
+                        let policy = self
+                            .android_config
+                            .key_attestation_only_policy
+                            .as_ref()
+                            .ok_or(AndroidKeyAttestationError::IntegrityTokenRequired)?;
+
+                        debug!("No Play Integrity token present; validating Android key attestation policy");
+
+                        verify_key_attestation_only_policy(&key_attestation, &self.android_config, policy).map_err(
+                            |error| {
+                                warn!("rejected Android key-attestation-only registration: '{error}'");
+                                error
+                            },
+                        )?;
+
+                        None
                     }
                 };
-
-                let _ = VerifiedIntegrityVerdict::verify_with_time(
-                    integrity_verdict,
-                    &self.android_config.package_name,
-                    &request_hash,
-                    &self.android_config.certificate_hashes,
-                    self.android_config.installation_method,
-                    attestation_timestamp,
-                )
-                .map_err(|error| {
-                    warn!(
-                        "rejected Android app attestation with integrity verdict: '{0}', cause: '{error}'",
-                        integrity_verdict_json,
-                    );
-                    AndroidAppAttestationError::IntegrityVerdict(error)
-                })?;
 
                 debug!("Checking registration signatures");
 
@@ -1776,6 +1919,7 @@ pub mod mock {
                 package_name: integrity_client.package_name.clone(),
                 certificate_hashes: integrity_client.certificate_hashes.clone(),
                 installation_method: InstallationMethod::default(),
+                key_attestation_only_policy: None,
             },
             crl,
             integrity_client,
@@ -2179,7 +2323,7 @@ mod tests {
                 let registration_message = ChallengeResponse::new_google(
                     &attested_private_key,
                     attested_certificate_chain.try_into().unwrap(),
-                    integrity_token,
+                    Some(integrity_token),
                     pin_privkey,
                     challenge,
                 )
@@ -3935,5 +4079,153 @@ mod tests {
             .expect_err("start pin recovery should fail due to wallet solution revoked");
 
         assert_matches!(err, InstructionError::WalletSolutionRevoked);
+    }
+}
+
+#[cfg(test)]
+mod key_attestation_only_policy_tests {
+    use std::collections::HashSet;
+
+    use android_attest::attestation_extension::key_attestation::KeyAttestation;
+    use android_attest::attestation_extension::key_description::SecurityLevel;
+    use android_attest::attestation_extension::key_description::VerifiedBootState;
+    use android_attest::play_integrity::verification::InstallationMethod;
+
+    use super::AndroidAttestationConfiguration;
+    use super::AndroidKeyAttestationError;
+    use super::KeyAttestationOnlyPolicy;
+    use super::verify_key_attestation_only_policy;
+
+    const PACKAGE_NAME: &str = "nl.test.wallet";
+    const SIGNATURE_DIGEST: &[u8] = b"app-signing-cert-digest";
+
+    fn test_config() -> AndroidAttestationConfiguration {
+        AndroidAttestationConfiguration {
+            root_public_keys: vec![],
+            package_name: PACKAGE_NAME.to_string(),
+            installation_method: InstallationMethod::PlayStore,
+            certificate_hashes: HashSet::from([SIGNATURE_DIGEST.to_vec()]),
+            key_attestation_only_policy: None,
+        }
+    }
+
+    fn strict_policy(require_matching_signature_digest: bool) -> KeyAttestationOnlyPolicy {
+        KeyAttestationOnlyPolicy {
+            allowed_verified_boot_states: vec![VerifiedBootState::Verified],
+            require_device_locked: true,
+            require_matching_signature_digest,
+        }
+    }
+
+    #[test]
+    fn accepts_hardware_backed_verified_locked_device() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::TrustedEnvironment,
+            VerifiedBootState::Verified,
+            true,
+            PACKAGE_NAME,
+            vec![SIGNATURE_DIGEST.to_vec()],
+        );
+
+        verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(true))
+            .expect("a hardware-backed, verified, locked device with a matching app should be accepted");
+    }
+
+    #[test]
+    fn rejects_software_only_attestation() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::Software,
+            VerifiedBootState::Verified,
+            true,
+            PACKAGE_NAME,
+            vec![SIGNATURE_DIGEST.to_vec()],
+        );
+
+        let error = verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(false))
+            .expect_err("a software-only attestation must be rejected");
+        assert!(matches!(
+            error,
+            AndroidKeyAttestationError::InsufficientSecurityLevel(SecurityLevel::Software)
+        ));
+    }
+
+    #[test]
+    fn rejects_disallowed_verified_boot_state() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::TrustedEnvironment,
+            VerifiedBootState::Unverified,
+            true,
+            PACKAGE_NAME,
+            vec![SIGNATURE_DIGEST.to_vec()],
+        );
+
+        let error = verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(false))
+            .expect_err("an unverified boot state must be rejected by the strict policy");
+        assert!(matches!(
+            error,
+            AndroidKeyAttestationError::VerifiedBootStateNotAccepted(VerifiedBootState::Unverified)
+        ));
+    }
+
+    #[test]
+    fn rejects_unlocked_bootloader_when_required() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::StrongBox,
+            VerifiedBootState::Verified,
+            false,
+            PACKAGE_NAME,
+            vec![SIGNATURE_DIGEST.to_vec()],
+        );
+
+        let error = verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(false))
+            .expect_err("an unlocked bootloader must be rejected when device lock is required");
+        assert!(matches!(error, AndroidKeyAttestationError::BootloaderNotLocked));
+    }
+
+    #[test]
+    fn rejects_mismatched_package_name() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::TrustedEnvironment,
+            VerifiedBootState::Verified,
+            true,
+            "com.malicious.app",
+            vec![SIGNATURE_DIGEST.to_vec()],
+        );
+
+        let error = verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(false))
+            .expect_err("a key attestation for a different app must be rejected");
+        assert!(matches!(
+            error,
+            AndroidKeyAttestationError::ApplicationIdentityMismatch(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_mismatched_signature_digest_when_required() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::TrustedEnvironment,
+            VerifiedBootState::Verified,
+            true,
+            PACKAGE_NAME,
+            vec![b"some-other-digest".to_vec()],
+        );
+
+        let error = verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(true))
+            .expect_err("a non-matching signing certificate digest must be rejected when required");
+        assert!(matches!(error, AndroidKeyAttestationError::SignatureDigestMismatch));
+    }
+
+    #[test]
+    fn ignores_signature_digest_when_not_required() {
+        let key_attestation = KeyAttestation::new_mock(
+            SecurityLevel::TrustedEnvironment,
+            VerifiedBootState::Verified,
+            true,
+            PACKAGE_NAME,
+            vec![b"some-other-digest".to_vec()],
+        );
+
+        verify_key_attestation_only_policy(&key_attestation, &test_config(), &strict_policy(false))
+            .expect("a non-matching digest should be ignored when signature digest matching is disabled");
     }
 }

--- a/wallet_core/wallet_provider/service/tests/account_server.rs
+++ b/wallet_core/wallet_provider/service/tests/account_server.rs
@@ -134,7 +134,7 @@ async fn do_registration(
             let registration_message = ChallengeResponse::new_google(
                 &attested_private_key,
                 attested_certificate_chain.try_into().unwrap(),
-                integrity_token,
+                Some(integrity_token),
                 pin_privkey,
                 challenge,
             )

--- a/wallet_core/wallet_provider/src/router_state.rs
+++ b/wallet_core/wallet_provider/src/router_state.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use android_attest::attestation_extension::key_description::VerifiedBootState;
 use android_attest::root_public_key::RootPublicKey;
 use audit_log::model::PostgresAuditLog;
 use chrono::Duration;
@@ -29,6 +30,7 @@ use wallet_provider_service::account_server::AccountServerKeys;
 use wallet_provider_service::account_server::AccountServerPinKeys;
 use wallet_provider_service::account_server::AndroidAttestationConfiguration;
 use wallet_provider_service::account_server::AppleAttestationConfiguration;
+use wallet_provider_service::account_server::KeyAttestationOnlyPolicy;
 use wallet_provider_service::account_server::UserState;
 use wallet_provider_service::flags::WalletRepoFlags;
 use wallet_provider_service::instructions::HandleInstruction;
@@ -106,11 +108,25 @@ impl<GRC, PIC> RouterState<GRC, PIC> {
             .into_iter()
             .map(RootPublicKey::from)
             .collect();
+        let android_key_attestation_only_policy = settings
+            .android
+            .key_attestation_only
+            .filter(|policy| policy.enabled)
+            .map(|policy| KeyAttestationOnlyPolicy {
+                allowed_verified_boot_states: policy
+                    .allowed_verified_boot_states
+                    .into_iter()
+                    .map(VerifiedBootState::from)
+                    .collect(),
+                require_device_locked: policy.require_device_locked,
+                require_matching_signature_digest: policy.require_matching_signature_digest,
+            });
         let android_config = AndroidAttestationConfiguration {
             root_public_keys: android_root_public_keys,
             package_name: settings.android.package_name,
             installation_method: android_installation_method,
             certificate_hashes: settings.android.play_store_certificate_hashes,
+            key_attestation_only_policy: android_key_attestation_only_policy,
         };
 
         let account_server = AccountServer::new(

--- a/wallet_core/wallet_provider/src/settings.rs
+++ b/wallet_core/wallet_provider/src/settings.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use android_attest::attestation_extension::key_description::VerifiedBootState;
 use android_attest::play_integrity::verification::InstallationMethod;
 use android_attest::root_public_key::RootPublicKey;
 use apple_app_attest::AttestationEnvironment;
@@ -168,6 +169,57 @@ pub struct Android {
     pub credentials_file: PathBuf,
     #[serde_as(as = "HashSet<Hex>")]
     pub play_store_certificate_hashes: HashSet<Vec<u8>>,
+    /// Optional policy for accepting registrations without a Google Play Integrity token, for
+    /// devices without Google Play services or a Google account (e.g. GrapheneOS, LineageOS, /e/OS).
+    /// When omitted, key-attestation-only registration is disabled.
+    #[serde(default)]
+    pub key_attestation_only: Option<AndroidKeyAttestationOnly>,
+}
+
+/// Configuration of the key-attestation-only registration path. See
+/// `wallet_provider_service::account_server::KeyAttestationOnlyPolicy` for the semantics.
+#[derive(Clone, Deserialize)]
+pub struct AndroidKeyAttestationOnly {
+    /// Whether registration without a Play Integrity token is accepted at all.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Verified boot states that are accepted. Defaults to only `verified`, the strongest state.
+    #[serde(default = "default_allowed_verified_boot_states")]
+    pub allowed_verified_boot_states: Vec<AndroidVerifiedBootState>,
+    /// Require a locked bootloader. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub require_device_locked: bool,
+    /// Require a matching app signing certificate digest. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub require_matching_signature_digest: bool,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AndroidVerifiedBootState {
+    Verified,
+    SelfSigned,
+    Unverified,
+    Failed,
+}
+
+impl From<AndroidVerifiedBootState> for VerifiedBootState {
+    fn from(value: AndroidVerifiedBootState) -> Self {
+        match value {
+            AndroidVerifiedBootState::Verified => VerifiedBootState::Verified,
+            AndroidVerifiedBootState::SelfSigned => VerifiedBootState::SelfSigned,
+            AndroidVerifiedBootState::Unverified => VerifiedBootState::Unverified,
+            AndroidVerifiedBootState::Failed => VerifiedBootState::Failed,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_allowed_verified_boot_states() -> Vec<AndroidVerifiedBootState> {
+    vec![AndroidVerifiedBootState::Verified]
 }
 
 #[derive(Clone, From, Into)]

--- a/wallet_core/wallet_provider/wallet_account/src/messages/registration.rs
+++ b/wallet_core/wallet_provider/wallet_account/src/messages/registration.rs
@@ -43,7 +43,12 @@ pub enum RegistrationAttestation {
     Google {
         #[serde_as(as = "Vec<Base64>")]
         certificate_chain: VecAtLeastTwo<Vec<u8>>,
-        integrity_token: String,
+        /// Google Play Integrity token. Optional: devices without Google Play services
+        /// (e.g. GrapheneOS, LineageOS, /e/OS) cannot produce one. When absent, the account
+        /// server falls back to validating the hardware key attestation certificate chain
+        /// alone, subject to its configured key attestation policy.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        integrity_token: Option<String>,
     },
 }
 
@@ -122,7 +127,7 @@ mod client {
         pub async fn new_google<SK, PK>(
             secure_key: &SK,
             certificate_chain: VecAtLeastTwo<Vec<u8>>,
-            integrity_token: String,
+            integrity_token: Option<String>,
             pin_signing_key: &PK,
             challenge: Vec<u8>,
         ) -> Result<Self, EncodeError>

--- a/wallet_core/wallet_provider/wallet_account/tests/registration.rs
+++ b/wallet_core/wallet_provider/wallet_account/tests/registration.rs
@@ -84,7 +84,7 @@ fn test_google_registration() {
     let msg = ChallengeResponse::<Registration>::new_google(
         &attested_private_key,
         attested_certificate_chain.try_into().unwrap(),
-        integrity_token,
+        Some(integrity_token),
         &pin_signing_key,
         challenge.to_vec(),
     )


### PR DESCRIPTION
# Support Android registration without Google Play Integrity (de-Googled devices)

## Why

Today an Android wallet registration requires **both** a hardware key attestation
certificate chain **and** a Google **Play Integrity** token. The Play Integrity
token needs Google Play services and, in practice, a signed-in Google account.
This excludes de-Googled devices — GrapheneOS, LineageOS, `/e/`OS, etc. — and any
device without a Google account, which is at odds with the goal of an inclusive,
vendor-neutral public digital identity wallet (and with the spirit of the Digital
Markets Act regarding dependence on Google Mobile Services).

## What

Make the Play Integrity token **optional**. When it is absent, the account server
falls back to validating the **hardware key attestation** alone, subject to a
configurable policy. This is a **replacement** of the app-integrity signal, not a
removal: the key attestation already provides a hardware root of trust (security
level, verified boot state, bootloader lock state) and binds the key to our app
via `attestation_application_id`. The "installed from the Play Store" signal is the
only thing dropped — which is irrelevant for de-Googled devices.

The new path is **disabled by default** and must be enabled per deployment.

## Changes

**Message** (`wallet_account`)
- `RegistrationAttestation::Google.integrity_token` is now `Option<String>`.

**Client** (`platform_support`)
- `app_attestation_token` is optional across the UDL, the `AttestedKeyBridge`
  FFI type, and the `KeyWithAttestation`/`AttestationData` enums.
- `AttestedKeyBridge.kt` degrades to a `null` token only on the specific Play
  Integrity error codes that mean Play services / Play Store / Google account are
  unavailable (`PLAY_INTEGRITY_UNAVAILABLE_ERROR_CODES`). Transient failures on
  genuine Google devices are still retried and surfaced, so they are never
  silently downgraded. `retryable` gained a `nonRetryable` predicate so permanent
  failures fail fast instead of retrying ~30s.

**Server** (`wallet_provider`)
- New `KeyAttestationOnlyPolicy` and `verify_key_attestation_only_policy`:
  requires a hardware-backed security level, an accepted verified boot state,
  optionally a locked bootloader, and binds to our app via the
  `attestation_application_id` (package name + optional signing-cert digest).
- Gated behind `[android.key_attestation_only]` settings (default disabled). When
  a token is absent and the policy is not enabled, registration is rejected,
  preserving current behaviour.

**Persistence**
- `integrity_verdict_json` is now nullable (new migration + entity/domain update).

## Security considerations

- **GrapheneOS, relocked bootloader** → `verified_boot_state = Verified`,
  `device_locked = true` → strong hardware guarantee; accepted by the default
  strict policy.
- **LineageOS / `/e/`OS with an unlocked bootloader** → `Unverified` /
  `device_locked = false` → weaker; **not** accepted by default. Whether to accept
  these is an explicit, documented deployment policy decision
  (`allowed_verified_boot_states`, `require_device_locked`).
- The hardware-backed security level is always required; a software-only
  attestation is never accepted on this path.

## Tests / verification

- Unit tests for `verify_key_attestation_only_policy` covering security level,
  verified boot state, device-lock, package-name and signature-digest checks.
- `cargo check --workspace --all-targets`, `cargo clippy`, and `cargo +nightly fmt
  --check` all pass; existing `wallet_account` / `android_attest` / `platform_support`
  tests pass.
- Follow-up suggested: an end-to-end `tests_integration` registration test for the
  token-less path (build a mock cert chain whose key description carries a
  `Verified` + locked root of trust and a matching `attestation_application_id`),
  and Android instrumented tests on a device without Play services.

## Config

```toml
[android.key_attestation_only]
enabled = true
allowed_verified_boot_states = ["verified"]
require_device_locked = true
require_matching_signature_digest = true
```